### PR TITLE
Fix mock auto spec and mock configure after patched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Fix
 
-- ?????
+- Improved configure_mock after already mock patched.
 
 ### Tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+<!--next-version-placeholder-->
+
+## v0.2.0 (16/06/2023)
+
+### Feature
+
+- Added feature to prevent miss typing mock methods such as "called" per "saller" setting dynamically the spec to the mocked type and improved configure_mock after already mock patched.
+
+### Fix
+
+- ?????
+
+### Tests
+
+- Added new tests
+
+## v0.1.0
+
+- First release of `mocker-builder`

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ clean:
 	rm -rf ./build ./dist
 
 run-demo:
-	python -m pytest main.py -vv -s -x
+	python -m pytest test_cases/main.py -vv -s -x
 
 html-doc:
 	cd $(DOCS_DIR); \

--- a/mocker_builder/mocker_builder.py
+++ b/mocker_builder/mocker_builder.py
@@ -49,7 +49,7 @@ _Patch = TypeVar('_Patch', bound=_PatchType)
 TypeSpec = TypeVar('TypeSpec', bound=Optional[Callable[..., object]])
 TypeAutoSpec = TypeVar('TypeAutoSpec', bound=Optional[Union[bool, object]])
 
-__version__ = "0.1.6"
+__version__ = "0.2.0"
 
 
 class MockerBuilderWarning:

--- a/test_cases/cases.py
+++ b/test_cases/cases.py
@@ -1,0 +1,16 @@
+from mocker_builder import MockerBuilder
+
+
+class TestCases(MockerBuilder):
+
+    @MockerBuilder.initializer
+    def mocker_builder_setup(self):
+        pass
+
+    def test_mock_dict(self):
+        foo = {'key': 'value'}
+        original = foo.copy()
+        with self.patch(foo, {'newkey': 'newvalue'}, clear=True):
+            assert foo == {'newkey': 'newvalue'}
+
+        assert foo == original

--- a/test_cases/my_heroes.py
+++ b/test_cases/my_heroes.py
@@ -177,6 +177,13 @@ class MyHeroes:  # HeroesRepository
     def my_hero(self, hero):
         self._my_hero = hero
 
+    def run_created_runtime_method(self):
+        try:
+            response = self.runtime_method()
+            print(response)
+        except Exception as ex:
+            print(f"Oops! {repr(ex)}")
+
     def does(self) -> str:
         hero_hobby = self._my_hero.get_my_hero_hobby()
         return hero_hobby.what_i_do


### PR DESCRIPTION
Added feature to prevent miss typing mock methods such as "called" per "saller" setting dynamically the spec to the mocked type and improved configure_mock after already mock patched.